### PR TITLE
more configuration options for rofi-power

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -2,13 +2,14 @@
 
 # the options can get rearranged or removed, the final output will not contain
 # %EXIT (and it's linebreak) unless `rofi-power` is appended an exit command
-OPTIONS="%EXIT\n%REBOOT\n%POWER\n%SUSPEND\n%HIBERNATE"
+OPTIONS="%LOCK\n%EXIT\n%REBOOT\n%POWER\n%SUSPEND\n%HIBERNATE"
 # additional options can be supplied to the launcher
 LAUNCHER_OPTIONS="$LAUNCHER_OPTIONS -width 30"
 USE_LOCKER="false"
 LOCKER="i3lock"
 
 # it is even possible to rename the options
+# KEYWORD_LOCK="Lock screen"
 # KEYWORD_REBOOT="Reboot system"
 # KEYWORD_POWER="Power-off system"
 # KEYWORD_SUSPEND="Suspend system"

--- a/config.sample
+++ b/config.sample
@@ -1,4 +1,16 @@
 # configuration for rofi-power tool
-LAUNCHER="rofi -width 30 -dmenu -i -p rofi-power:"
+
+# the options can get rearranged or removed, the final output will not contain
+# %EXIT (and it's linebreak) unless `rofi-power` is appended an exit command
+OPTIONS="%EXIT\n%REBOOT\n%POWER\n%SUSPEND\n%HIBERNATE"
+# additional options can be supplied to the launcher
+LAUNCHER_OPTIONS="$LAUNCHER_OPTIONS -width 30"
 USE_LOCKER="false"
 LOCKER="i3lock"
+
+# it is even possible to rename the options
+# KEYWORD_REBOOT="Reboot system"
+# KEYWORD_POWER="Power-off system"
+# KEYWORD_SUSPEND="Suspend system"
+# KEYWORD_HIBERNATE="Hibernate system"
+KEYWORD_EXIT="Exit i3wm"

--- a/rofi-power
+++ b/rofi-power
@@ -7,6 +7,7 @@
 # adapted by Dennis Schürholz in 2017 - https://dennisschuerholz.de
 
 # KEYWORDS can be translated in the local configuration file
+KEYWORD_LOCK="Lock screen"
 KEYWORD_REBOOT="Reboot system"
 KEYWORD_POWER="Power-off system"
 KEYWORD_SUSPEND="Suspend system"
@@ -39,7 +40,7 @@ fi
 
 if [ -z "$OPTIONS" ]; then
   # default menu structure
-  OPTIONS="%EXIT\n%REBOOT\n%POWER\n%SUSPEND\n%HIBERNATE"
+  OPTIONS="%LOCK\n%EXIT\n%REBOOT\n%POWER\n%SUSPEND\n%HIBERNATE"
 fi
 if [ "$#" -eq 0 ]; then
   # EXIT is not needed so it gets removes (incl. it's line break)
@@ -47,13 +48,16 @@ if [ "$#" -eq 0 ]; then
 fi
 
 # replace placeholder elements with actual options
-OPTIONS=`echo $OPTIONS | sed -e "s/%REBOOT/$KEYWORD_REBOOT/" -e "s/%POWER/$KEYWORD_POWER/" -e "s/%SUSPEND/$KEYWORD_SUSPEND/" -e "s/%HIBERNATE/$KEYWORD_HIBERNATE/" -e "s/%EXIT/$KEYWORD_EXIT/"`
+OPTIONS=`echo $OPTIONS | sed -e "s/%REBOOT/$KEYWORD_REBOOT/" -e "s/%POWER/$KEYWORD_POWER/" -e "s/%SUSPEND/$KEYWORD_SUSPEND/" -e "s/%HIBERNATE/$KEYWORD_HIBERNATE/" -e "s/%EXIT/$KEYWORD_EXIT/" -e "s/%LOCK/$KEYWORD_LOCK/"`
 
 wc=`echo -e $OPTIONS | wc -l`
 option=`echo -e $OPTIONS | rofi -dmenu -lines $wc $LAUNCHER_OPTIONS | tr -d '\r\n'`
 if [ ${#option} -gt 0 ]
 then
     case $option in
+      $KEYWORD_LOCK)
+        $LOCKER
+        ;;
       $KEYWORD_EXIT)
         eval $1
         ;;

--- a/rofi-power
+++ b/rofi-power
@@ -4,40 +4,59 @@
 # Use rofi to call systemctl for shutdown, reboot, etc
 
 # 2016 Oliver Kraitschy - http://okraits.de
+# adapted by Dennis Schürholz in 2017 - https://dennisschuerholz.de
 
-OPTIONS="Reboot system\nPower-off system\nSuspend system\nHibernate system"
+# KEYWORDS can be translated in the local configuration file
+KEYWORD_REBOOT="Reboot system"
+KEYWORD_POWER="Power-off system"
+KEYWORD_SUSPEND="Suspend system"
+KEYWORD_HIBERNATE="Hibernate system"
+KEYWORD_EXIT="Exit window manager"
+USE_LOCKER="false"
+LOCKER="i3lock"
+# the default LAUNCHER_OPTIONS are exported to give the possibility to add
+# custom additional options in the local configuration file
+export LAUNCHER_OPTIONS="-i -p rofi-power:"
 
 # source configuration or use default values
 if [ -f $HOME/.config/rofi-power/config ]; then
   source $HOME/.config/rofi-power/config
-else
-  LAUNCHER="rofi -width 30 -dmenu -i -p rofi-power:"
-  USE_LOCKER="false"
-  LOCKER="i3lock"
 fi
 
 # Show exit wm option if exit command is provided as an argument
 if [ ${#1} -gt 0 ]; then
   OPTIONS="Exit window manager\n$OPTIONS"
 fi
+if [ -z "$OPTIONS" ]; then
+  # default menu structure
+  OPTIONS="%EXIT\n%REBOOT\n%POWER\n%SUSPEND\n%HIBERNATE"
+fi
+if [ "$#" -eq 0 ]; then
+  # EXIT is not needed so it gets removes (incl. it's line break)
+  OPTIONS=`echo $OPTIONS | sed -e 's/%EXIT\\\\n//g' -e 's/\\\\n%EXIT//g' -e 's/%EXIT\\\\r\\\\n//g' -e 's/\\\\r\\\\n%EXIT//g'`
+fi
 
-option=`echo -e $OPTIONS | $LAUNCHER | awk '{print $1}' | tr -d '\r\n'`
+# replace placeholder elements with actual options
+OPTIONS=`echo $OPTIONS | sed -e "s/%REBOOT/$KEYWORD_REBOOT/" -e "s/%POWER/$KEYWORD_POWER/" -e "s/%SUSPEND/$KEYWORD_SUSPEND/" -e "s/%HIBERNATE/$KEYWORD_HIBERNATE/" -e "s/%EXIT/$KEYWORD_EXIT/"`
+
+wc=`echo -e $OPTIONS | wc -l`
+option=`echo -e $OPTIONS | rofi -dmenu -lines $wc $LAUNCHER_OPTIONS | tr -d '\r\n'`
 if [ ${#option} -gt 0 ]
 then
     case $option in
-      Exit)
+      $KEYWORD_EXIT)
         eval $1
         ;;
-      Reboot)
+      $KEYWORD_REBOOT)
         systemctl reboot
         ;;
-      Power-off)
+      $KEYWORD_POWER)
         systemctl poweroff
         ;;
-      Suspend)
+      $KEYWORD_SUSPEND)
         $($USE_LOCKER) && "$LOCKER"; systemctl suspend
         ;;
-      Hibernate)
+      $KEYWORD_HIBERNATE)
         $($USE_LOCKER) && "$LOCKER"; systemctl hibernate
         ;;
       *)

--- a/rofi-power
+++ b/rofi-power
@@ -23,10 +23,20 @@ if [ -f $HOME/.config/rofi-power/config ]; then
   source $HOME/.config/rofi-power/config
 fi
 
-# Show exit wm option if exit command is provided as an argument
-if [ ${#1} -gt 0 ]; then
-  OPTIONS="Exit window manager\n$OPTIONS"
+# runtime options override static config
+if [ "$ENV_OPTIONS" ]; then
+  OPTIONS=$ENV_OPTIONS
 fi
+if [ "$ENV_LAUNCHER_OPTIONS" ]; then
+  LAUNCHER_OPTIONS=$ENV_LAUNCHER_OPTIONS
+fi
+if [ "$ENV_USE_LOCKER" ]; then
+  USE_LOCKER=$ENV_USE_LOCKER
+fi
+if [ "$ENV_LOCKER" ]; then
+  LOCKER=$ENV_LOCKER
+fi
+
 if [ -z "$OPTIONS" ]; then
   # default menu structure
   OPTIONS="%EXIT\n%REBOOT\n%POWER\n%SUSPEND\n%HIBERNATE"


### PR DESCRIPTION
As I started using i3 yesterday I came accross your little tool and liked it - thought I wanted some additional configuration options which this pr introduces:
* config file now overrides defaults as it should be (defaults get set, config is loaded afterwards)
* options are renameable (configuration file may set e.g. `KEYWORD_EXIT`, `KEYWORD_REBOOT`, `KEYWORKD_SUSPEND`, ...)
* option order and their presence can be configured (`OPTIONS` contains placeholder elements, e.g. `%EXIT`, `%REBOOT`, `%SUSPEND`, ...)
* new option: "lock screen" (`KEYWORD_LOCK="Lock screen"`, placeholder `%LOCK`)
* some configuration (`OPTIONS` (option order), `LAUNCHER_OPTIONS`, `USE_LOCKER` and `LOCKER`) can be overwritten through the calling shell setting `ENV_<var>` beforehand
* `LAUNCHER` gets replaced by static `rofi -dmenu -lines $wc` (where `$wc` is the line count through `wc -l`) followed by the configurable `LAUNCHER_OPTIONS` as I don't think calling `rofi` is something that might get replaced while using `rofi_power`

I have to admin that it almost looks like a complete rewrite, but I hope you might still consider this pr. I will use it like this and assume some others might like it as well.
Best regars, Dennis